### PR TITLE
Feat/get fonts working

### DIFF
--- a/src/serverSetup/middlewares.js
+++ b/src/serverSetup/middlewares.js
@@ -17,7 +17,7 @@ export function setupMiddlewares (app) {
   //   next()
   // })
 
-  app.use('/assets', express.static('./node_modules/govuk-frontend/govuk/assets'))
+  app.use('/assets', express.static('./node_modules/govuk-frontend/dist/govuk/assets'))
   app.use('/public', express.static('./public'))
 
   app.use(cookieParser())

--- a/src/views/layouts/main.html
+++ b/src/views/layouts/main.html
@@ -70,6 +70,5 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
     {{ super()}}
   {%block scripts %}
     {{ super() }}
-    <script src="/public/js/application.bundle.js"></script>
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Ticket: https://trello.com/c/lAb9hob6/3310-content-changes-spotted-by-alex?filter=label:Endpoint%20Submission%20Form,member:georgegoodall8

this ticket makes sure the fonts are correctly loaded as the path to the govuk-frontend assets in node modules has changed when compared to the older version